### PR TITLE
fixes errors with enums patches

### DIFF
--- a/pkg/patch/apply.go
+++ b/pkg/patch/apply.go
@@ -49,6 +49,7 @@ func Apply(target interface{}, patch map[string]interface{}) (changed bool, err 
 			changed = true
 		}
 
+		srcValue = srcValue.Convert(reflect.TypeOf(dstField.Value()))
 		err = dstField.Set(srcValue.Interface())
 		if err != nil {
 			return


### PR DESCRIPTION
- when updating the shipment status (as it's an enum) it was failing because the type was not exactly the same
- Added a specific type conversion