### PR TITLE
preventing conversion panics

### DIFF
--- a/pkg/patch/apply.go
+++ b/pkg/patch/apply.go
@@ -49,6 +49,10 @@ func Apply(target interface{}, patch map[string]interface{}) (changed bool, err 
 			changed = true
 		}
 
+		if !srcValue.CanConvert(reflect.TypeOf(dstField.Value())) {
+			err = fmt.Errorf("can't convert %v to dst type", name)
+			return
+		}
 		srcValue = srcValue.Convert(reflect.TypeOf(dstField.Value()))
 		err = dstField.Set(srcValue.Interface())
 		if err != nil {

--- a/pkg/patch/apply_test.go
+++ b/pkg/patch/apply_test.go
@@ -190,3 +190,22 @@ func TestEnums(t *testing.T) {
 	assert.Equal(t, "Vader", a.LastName)
 	assert.Equal(t, Position_Sith, a.Position)
 }
+
+func TestSkipConversionErrors(t *testing.T) {
+	type Target struct {
+		Characters []string `json:"characters"`
+	}
+	var a = &Target{
+		Characters: []string{"Anakin Skywalker"},
+	}
+
+	newWrongCharacters := `{"characters":[1,2,3]}`
+	p := make(map[string]interface{})
+	jsonErr := json.Unmarshal([]byte(newWrongCharacters), &p)
+	assert.NoError(t, jsonErr)
+
+	_, err := Apply(&a, p)
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "can't convert characters to dst type")
+	assert.Equal(t, []string{"Anakin Skywalker"}, a.Characters) // unchanged
+}


### PR DESCRIPTION
- If types of `map[string]interface{}` were coincident but inner values not, there was a panic